### PR TITLE
Add glossary.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,8 @@
-# Glossary
-## Proper names
-Note the capitalization in the following words. Obvious words are not included like: **Google** or **Bing**. Programming languages and frameworks are included though
+# Best Practices
 
-- **Amazon EC2** (Amazon **E**lastic **C**ompute **C**loud) - is a web service that provides resizable compute capacity in the cloud
-- **API** (**A**pplication **P**rogram **I**nterface)
-- **AWS** (**A**mazon **W**eb **S**ervices)
-- **B2B** (**B**usiness to **B**usiness)
-- **B2C** (**B**usiness to **C**ustomer)
-- **BaaS** (**B**ackend **a**s **a** **S**ervice)
-- **CD** (depending on context) **C**ontinuous **D**elivery, **C**ontinuous **D**eployment, **C**ompact **D**isk 
-- **CI** - **C**ontinuous **I**ntegration
-- **CircleCI**
-- **CLI** (**C**ommand **L**ine **I**nterface)
-- **CSS** (**C**ascading **S**tyle **S**heets)
-- **CSV** (**C**omma **S**eparated **V**alue)
-- **DB** (Database)
-- **DBMS** (Database **M**anagement **S**ystem)
-- **Django**
-- **DuckDuckGo**
-- **Firebase**
-- **Flask**
-- **GCP** (**G**oogle **C**loud **P**latfrom)
-- **Git**
-- **GitHub**
-- **GraphQL**
-- **JavaScript**
-- **Jinja** template engine (or simply Jinja)
-- **MongoDB**
-- **NuxtJS**
-- **ORM** (**O**bject **R**elational **M**apper)
-- **PHP**
-- **PostgreSQL**
-- **Python**
-- **React Native**
-- **React Redux** (or simple Redux)
-- **ReactJS**
-- **REST** (**RE**presentational **S**tate **T**ransfer) - sometimes written as `RESTful API`. More info [here][1]
-- **Ruby**
-- **Ruby on Rails** (or simply Rails)
-- **SaaS** (**S**oftware **a**s **a** **S**ervice)
-- **SDK** (**S**oftware **D**evelopment **K**it)
-- **SOAP API** (**S**imple **O**bject **A**ccess **P**rotocol) - is an application communication protocol. Compare with REST [here][2]
-- **SQL** (**S**tructured **Q**uery **L**anguage)
-- **SQLAlchemy** - is a Python SQL toolkit and ORM
-- **SQLite** - is a relational database management system contained in a C library
-- **TDD** (**T**est **D**riven **D**evelopment)
-- **VueJS**
+In this repo we outline the best practices for authors writing on the CircleCI blog.
 
----
-**NB**: This is a growing list (PRs are [welcome][3]. Please maintain the alphabetic order)
+## Contents
+1. [Glossary][glossary]
 
-[1]: https://restfulapi.net/
-[2]: https://restfulapi.net/soap-vs-rest-apis/
-[3]: https://github.com/CIRCLECI-GWP/glossary/edit/master/README.md
+[glossary]: /glossary.md

--- a/glossary.md
+++ b/glossary.md
@@ -1,0 +1,57 @@
+# Glossary
+## Proper names
+Note the capitalization in the following words. Obvious words are not included like: **Google** or **Bing**. Programming languages and frameworks are included though.
+
+- **Amazon EC2** (Amazon **E**lastic **C**ompute **C**loud) - is a web service that provides resizable compute capacity in the cloud
+- **API** (**A**pplication **P**rogram **I**nterface)
+- **AWS** (**A**mazon **W**eb **S**ervices)
+- **B2B** (**B**usiness to **B**usiness)
+- **B2C** (**B**usiness to **C**ustomer)
+- **BaaS** (**B**ackend **a**s **a** **S**ervice)
+- **CD** (depending on context) **C**ontinuous **D**elivery, **C**ontinuous **D**eployment, **C**ompact **D**isk 
+- **CI** - **C**ontinuous **I**ntegration
+- **CircleCI** not *Circle CI* nor *Circleci*
+- **CLI** (**C**ommand **L**ine **I**nterface)
+- **CSS** (**C**ascading **S**tyle **S**heets)
+- **CSV** (**C**omma **S**eparated **V**alue)
+- **DB** (Database)
+- **DBMS** (Database **M**anagement **S**ystem)
+- **Django**
+- **Docker**
+- **DuckDuckGo**
+- **Firebase**
+- **Flask**
+- **GCP** (**G**oogle **C**loud **P**latfrom)
+- **Git**
+- **GitHub**
+- **GraphQL**
+- **JavaScript**
+- **Jinja** template engine (or simply Jinja)
+- **MongoDB**
+- **NodeJS**
+- **NuxtJS**
+- **ORM** (**O**bject **R**elational **M**apper)
+- **PHP**
+- **PostgreSQL**
+- **Python**
+- **React Native**
+- **React Redux** (or simple Redux)
+- **ReactJS**
+- **REST** (**RE**presentational **S**tate **T**ransfer) - sometimes written as `RESTful API`. More info [here][1]
+- **Ruby**
+- **Ruby on Rails** (or simply Rails)
+- **SaaS** (**S**oftware **a**s **a** **S**ervice)
+- **SDK** (**S**oftware **D**evelopment **K**it)
+- **SOAP API** (**S**imple **O**bject **A**ccess **P**rotocol) - is an application communication protocol. Compare with REST [here][2]
+- **SQL** (**S**tructured **Q**uery **L**anguage)
+- **SQLAlchemy** - is a Python SQL toolkit and ORM
+- **SQLite** - is a relational database management system contained in a C library
+- **TDD** (**T**est **D**riven **D**evelopment)
+- **VueJS**
+
+---
+**NB**: This is a growing list (PRs are [welcome][3]. Please maintain the alphabetic order)
+
+[1]: https://restfulapi.net/
+[2]: https://restfulapi.net/soap-vs-rest-apis/
+[3]: https://github.com/CIRCLECI-GWP/glossary/edit/master/README.md


### PR DESCRIPTION
#### What does this PR do?
Since the repo was renamed to *best-practices*, the glossary moves to `glossary.md`
#### Any background context you want to provide?
Following a meeting with @ronpowelljr, we thought it best to rename since we'll add more tips and tricks for authors for their reference.